### PR TITLE
Feature: mutable expressions in `assert_panic!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.2
+
+Improve `assert_panic!` to support mutable expressions. It now supports:
+
+```rust
+let mut list = Vec::new();
+assert_panic!("bounds" in {
+    list.push(123);
+    let _ = list[1];
+});
+```
+
 ## 0.2.1
 
 Update documentation metadata for https://docs.rs/.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "tux"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "path-clean",
  "reqwest",

--- a/tux/Cargo.toml
+++ b/tux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tux"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Test utilities for unit and integration tests"
 license = "MIT"

--- a/tux/src/assert_panic.rs
+++ b/tux/src/assert_panic.rs
@@ -21,7 +21,7 @@ macro_rules! assert_panic {
 		let expected_message = $message;
 		let prev_hook = std::panic::take_hook();
 		std::panic::set_hook(Box::new(|_| {}));
-		let result = std::panic::catch_unwind(|| $code);
+		let result = std::panic::catch_unwind(move || $code);
 		std::panic::set_hook(prev_hook);
 		let err = result
 			.err()
@@ -86,5 +86,14 @@ mod tests {
 	fn supports_formatted_panic_messages() {
 		let value = 123;
 		assert_panic!("panic with 123" in panic!("panic with {}", value));
+	}
+
+	#[test]
+	fn supports_mutable_expressions() {
+		let mut list = Vec::new();
+		assert_panic!("bounds" in {
+			list.push(123);
+			let _ = list[1];
+		});
 	}
 }


### PR DESCRIPTION
Improve `assert_panic!` to support mutable expressions. It now supports:

```rust
let mut list = Vec::new();
assert_panic!("bounds" in {
    list.push(123);
    let _ = list[1];
});
```

Closes #4 